### PR TITLE
Bump `symfony/var-dumper` from `v7.3.1` to `v7.3.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "infection/infection": "~0.31.0",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.2.9",
-        "symfony/var-dumper": "~7.3.1",
+        "symfony/var-dumper": "~7.3.2",
         "vimeo/psalm": "~6.13.0"
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ef8cade1cf47f3b0789fcf06d36c9f0",
+    "content-hash": "8ccb3bda0b3b14ec900ee633abf64687",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -7402,16 +7402,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42"
+                "reference": "53205bea27450dc5c65377518b3275e126d45e75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
-                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/53205bea27450dc5c65377518b3275e126d45e75",
+                "reference": "53205bea27450dc5c65377518b3275e126d45e75",
                 "shasum": ""
             },
             "require": {
@@ -7423,7 +7423,6 @@
                 "symfony/console": "<6.4"
             },
             "require-dev": {
-                "ext-iconv": "*",
                 "symfony/console": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
                 "symfony/process": "^6.4|^7.0",
@@ -7466,7 +7465,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.1"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -7478,11 +7477,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2025-07-29T20:02:46+00:00"
         },
         {
             "name": "thecodingmachine/safe",


### PR DESCRIPTION
Bumps `symfony/var-dumper` from `v7.3.1` to `v7.3.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`