### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main#cfeb5f6`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1067,12 +1067,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "cdb4299c7eeaa4dfdba7f07939db077dc7a07747"
+                "reference": "cfeb5f63c6d1ba1c28c98460506fb2839566e87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/cdb4299c7eeaa4dfdba7f07939db077dc7a07747",
-                "reference": "cdb4299c7eeaa4dfdba7f07939db077dc7a07747",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/cfeb5f63c6d1ba1c28c98460506fb2839566e87b",
+                "reference": "cfeb5f63c6d1ba1c28c98460506fb2839566e87b",
                 "shasum": ""
             },
             "require": {
@@ -1228,7 +1228,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-02T02:48:29+00:00"
+            "time": "2025-09-02T12:00:35+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#cfeb5f6`.

This pull request changes the following file(s): 

- Update `composer.lock`