### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#d573118`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1127,12 +1127,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db"
+                "reference": "d573118708d6ec7ecaa2189d7c06a00c9226a16e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/b41b8c9261587c68541e6bf38933426ce8b9c8db",
-                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d573118708d6ec7ecaa2189d7c06a00c9226a16e",
+                "reference": "d573118708d6ec7ecaa2189d7c06a00c9226a16e",
                 "shasum": ""
             },
             "require": {
@@ -1289,7 +1289,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T17:06:16+00:00"
+            "time": "2025-09-11T18:12:00+00:00"
         },
         {
             "name": "ghostwriter/option",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#b41b8c9` to `dev-main#d573118`.

This pull request changes the following file(s): 

- Update `composer.lock`