### PR TITLE
Update ghostwriter/json to version 3.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ghostwriter/container": "^5.0.1",
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/filesystem": "^0.1.1",
-        "ghostwriter/json": "^3.0.0"
+        "ghostwriter/json": "^3.0.1"
     },
     "require-dev": {
         "ext-xdebug": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ee076a11860d1a377c182285b8bb267",
+    "content-hash": "1aceabd4e3a6c99eba4dd05472a6ba4a",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -442,27 +442,38 @@
         },
         {
             "name": "ghostwriter/json",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/json.git",
-                "reference": "233cb60e91ec3760ff849cf4b371fcc892819c6b"
+                "reference": "a672903f17a2f5e3a0359436ef7a10b3cf33462b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/json/zipball/233cb60e91ec3760ff849cf4b371fcc892819c6b",
-                "reference": "233cb60e91ec3760ff849cf4b371fcc892819c6b",
+                "url": "https://api.github.com/repos/ghostwriter/json/zipball/a672903f17a2f5e3a0359436ef7a10b3cf33462b",
+                "reference": "a672903f17a2f5e3a0359436ef7a10b3cf33462b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^8.3"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
+                "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/psalm-plugin": "^0.1 || ^0.2 || ^1.0"
+                "ghostwriter/container": "^6.0.1",
+                "mockery/mockery": "^1.6.12",
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
+            "extra": {
+                "ghostwriter": {
+                    "container": {
+                        "definition": "Ghostwriter\\Json\\Container\\JsonDefinition"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Ghostwriter\\Json\\": "src/"
@@ -470,7 +481,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "BSD-4-Clause"
             ],
             "authors": [
                 {
@@ -487,10 +498,9 @@
                 "json"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/json",
-                "forum": "https://github.com/ghostwriter/json/discussions",
                 "issues": "https://github.com/ghostwriter/json/issues",
                 "rss": "https://github.com/ghostwriter/json/releases.atom",
+                "security": "https://github.com/ghostwriter/json/security/advisories/new",
                 "source": "https://github.com/ghostwriter/json"
             },
             "funding": [
@@ -499,7 +509,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-09T19:45:55+00:00"
+            "time": "2025-11-25T16:30:02+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Updates the `ghostwriter/json` dependency from `3.0.0` to `3.0.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`