### PR TITLE
Update ghostwriter/config to version 2.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "ghostwriter/case-converter": "^2.2.1",
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.0.0",
-        "ghostwriter/config": "^2.0.2",
+        "ghostwriter/config": "^2.1.1",
         "ghostwriter/container": "^6.1.1",
         "ghostwriter/event-dispatcher": "^6.1.0",
         "ghostwriter/filesystem": "^0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7be50189ad0da5be8862a076d23b6091",
+    "content-hash": "5e333311e357a7394772d5c2db7c76cb",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -216,16 +216,16 @@
         },
         {
             "name": "ghostwriter/config",
-            "version": "2.0.2",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/config.git",
-                "reference": "27a8517b8b344e9744262357c4cc6246ba9b73f4"
+                "reference": "11076c766c7e7c23a4e2806154f0e641edb686fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/config/zipball/27a8517b8b344e9744262357c4cc6246ba9b73f4",
-                "reference": "27a8517b8b344e9744262357c4cc6246ba9b73f4",
+                "url": "https://api.github.com/repos/ghostwriter/config/zipball/11076c766c7e7c23a4e2806154f0e641edb686fa",
+                "reference": "11076c766c7e7c23a4e2806154f0e641edb686fa",
                 "shasum": ""
             },
             "require": {
@@ -234,10 +234,10 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/container": "^6.0.1",
+                "ghostwriter/container": "^6.1.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.5.3",
-                "symfony/var-dumper": "^8.0.0"
+                "phpunit/phpunit": "^13.1.3",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
             "extra": {
@@ -247,7 +247,9 @@
                 },
                 "ghostwriter": {
                     "container": {
-                        "definition": "Ghostwriter\\Config\\Container\\ConfigurationDefinition"
+                        "provider": [
+                            "Ghostwriter\\Config\\Container\\ConfigurationProvider"
+                        ]
                     }
                 }
             },
@@ -258,7 +260,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -286,7 +288,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-14T23:37:43+00:00"
+            "time": "2026-04-14T22:24:27+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `ghostwriter/config` dependency from `2.0.2` to `2.1.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`