### PR TITLE
Update ghostwriter/case-converter to version 2.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
-        "ghostwriter/case-converter": "^2.2.1",
+        "ghostwriter/case-converter": "^2.2.2",
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.1.0",
         "ghostwriter/config": "^2.1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c1aaf1432518eb04a5ff2e542b80048",
+    "content-hash": "7c01d747b4741a3363c32de573a52bbb",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/case-converter.git",
-                "reference": "feed5dffb93164313bfd490ff160ed059bf209a7"
+                "reference": "87dba3bcb7bf6909cc721988ef35d1ee16a95545"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/feed5dffb93164313bfd490ff160ed059bf209a7",
-                "reference": "feed5dffb93164313bfd490ff160ed059bf209a7",
+                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/87dba3bcb7bf6909cc721988ef35d1ee16a95545",
+                "reference": "87dba3bcb7bf6909cc721988ef35d1ee16a95545",
                 "shasum": ""
             },
             "require": {
@@ -27,9 +27,9 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/container": "^6.1.1",
+                "ghostwriter/container": "^7.0.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.1.3",
+                "phpunit/phpunit": "^13.1.7",
                 "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
@@ -93,7 +93,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-14T16:15:45+00:00"
+            "time": "2026-04-22T20:29:50+00:00"
         },
         {
             "name": "ghostwriter/clock",


### PR DESCRIPTION
Updates the `ghostwriter/case-converter` dependency from `2.2.1` to `2.2.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`