### PR TITLE
Update boundwize/structarmed to version 0.6.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.10",
+        "boundwize/structarmed": "^0.6.13",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70e827f9491f7412e60a72f1612f4f70",
+    "content-hash": "1b388e6722a92ba362909974f8599cd8",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -719,16 +719,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.10",
+            "version": "0.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "893d7fb54627be9bfc127fbddaaaa1921fd026aa"
+                "reference": "7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/893d7fb54627be9bfc127fbddaaaa1921fd026aa",
-                "reference": "893d7fb54627be9bfc127fbddaaaa1921fd026aa",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc",
+                "reference": "7a6e3a9e4b8e7ae6cb344c5933240a8d71dd62bc",
                 "shasum": ""
             },
             "require": {
@@ -777,7 +777,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.10"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.13"
             },
             "funding": [
                 {
@@ -785,7 +785,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-19T10:47:01+00:00"
+            "time": "2026-05-19T15:51:33+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.10` to `0.6.13`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`