### PR TITLE
Update `boundwize/structarmed` to version `0.10.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.9.5",
+        "boundwize/structarmed": "^0.10.0",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4445735df4fbdec198b6b098049a748a",
+    "content-hash": "4ba1170b6b05499b93177779035ed76d",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -793,16 +793,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0"
+                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
-                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/5e488b5c1502a92e3cef8cf25b87b77e877b9804",
+                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804",
                 "shasum": ""
             },
             "require": {
@@ -855,7 +855,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.9.5"
+                "source": "https://github.com/boundwize/structarmed/tree/0.10.0"
             },
             "funding": [
                 {
@@ -863,7 +863,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T07:01:44+00:00"
+            "time": "2026-06-01T18:39:11+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.9.5` to `0.10.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`